### PR TITLE
Last bugfix

### DIFF
--- a/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
+++ b/streams/src/main/java/org/apache/kafka/streams/processor/internals/AssignedTasks.java
@@ -193,12 +193,7 @@ abstract class AssignedTasks<T extends Task> {
                 }
             } catch (final TaskMigratedException e) {
                 log.info("Failed to commit {} {} since it got migrated to another thread already. " +
-                        "Closing it as zombie before triggering a new rebalance.", taskTypeName, task.id());
-                final RuntimeException fatalException = closeZombieTask(task);
-                if (fatalException != null) {
-                    throw fatalException;
-                }
-                it.remove();
+                        "Will trigger a new rebalance and close all tasks as zombies.", taskTypeName, task.id());
                 throw e;
             } catch (final RuntimeException t) {
                 log.error("Failed to commit {} {} due to the following error:",


### PR DESCRIPTION
Final bugfix (solves both the "`RocksDbException: `no locks available" and "`NPE` on `dbAccessor`" issues) 

In `AssignedTasks` (the abstract class from which the standby and active task variations extend) a commit failure (even due to broker down/unavailable) is treated as a `TaskMigratedException` after which the failed task is closed as a zombie and removed from `running` -- the remaining tasks (ie those still in `running` are then also closed as zombies in the subsequent `onPartitionsLost`

However we do not remove the closed task from `runningByPartition` nor do we remove the corresponding changelogs, if restoring, from the `StoreChangelogReader` since that applies only to active tasks, and `AssignedTasks` is generic/abstract. The changelog reader then retains a mapping from the closed task's changelog partition to its `CompositeRestoreListener` (and does not replace this when the new one comes along after the rebalance). The restore listener has a reference to a specific `RocksDBStore` instance, one which was closed when the task was closed as a zombie, so it accidentally tries to restore to the "old" `RocksDBStore` instance rather than the new one that was just opened.