### PR TITLE
A few improvements to envelope handling

### DIFF
--- a/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
+++ b/clients/src/main/java/org/apache/kafka/clients/KafkaClient.java
@@ -180,6 +180,7 @@ public interface KafkaClient extends Closeable {
 
     /**
      * Create a new ClientRequest.
+     *
      * @param nodeId the node to send to
      * @param requestBuilder the request builder to use
      * @param createdTimeMs the time in milliseconds to use as the creation time of the request

--- a/clients/src/main/java/org/apache/kafka/common/errors/PrincipalDeserializationException.java
+++ b/clients/src/main/java/org/apache/kafka/common/errors/PrincipalDeserializationException.java
@@ -19,11 +19,11 @@ package org.apache.kafka.common.errors;
 /**
  * Exception used to indicate a kafka principal deserialization failure during request forwarding.
  */
-public class PrincipalDeserializationFailureException extends AuthorizationException {
+public class PrincipalDeserializationException extends ApiException {
 
     private static final long serialVersionUID = 1L;
 
-    public PrincipalDeserializationFailureException(String message) {
+    public PrincipalDeserializationException(String message) {
         super(message);
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
+++ b/clients/src/main/java/org/apache/kafka/common/protocol/Errors.java
@@ -84,7 +84,7 @@ import org.apache.kafka.common.errors.OperationNotAttemptedException;
 import org.apache.kafka.common.errors.OutOfOrderSequenceException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.PreferredLeaderNotAvailableException;
-import org.apache.kafka.common.errors.PrincipalDeserializationFailureException;
+import org.apache.kafka.common.errors.PrincipalDeserializationException;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.ReassignmentInProgressException;
 import org.apache.kafka.common.errors.RebalanceInProgressException;
@@ -341,7 +341,7 @@ public enum Errors {
     INVALID_UPDATE_VERSION(95, "The given update version was invalid.", InvalidUpdateVersionException::new),
     FEATURE_UPDATE_FAILED(96, "Unable to update finalized features due to an unexpected server error.", FeatureUpdateFailedException::new),
     PRINCIPAL_DESERIALIZATION_FAILURE(97, "Request principal deserialization failed during forwarding. " +
-         "This indicates an internal error on the broker cluster security setup.", PrincipalDeserializationFailureException::new);
+         "This indicates an internal error on the broker cluster security setup.", PrincipalDeserializationException::new);
 
     private static final Logger log = LoggerFactory.getLogger(Errors.class);
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeResponse.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/EnvelopeResponse.java
@@ -42,7 +42,7 @@ public class EnvelopeResponse extends AbstractResponse {
         this.data = data;
     }
 
-    public ByteBuffer embedResponseData() {
+    public ByteBuffer responseData() {
         return data.responseData();
     }
 

--- a/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/RequestContext.java
@@ -24,11 +24,13 @@ import org.apache.kafka.common.network.Send;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.types.Struct;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.common.security.auth.KafkaPrincipalSerde;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
 
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
-import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import java.util.Optional;
 
 import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
 
@@ -41,6 +43,7 @@ public class RequestContext implements AuthorizableRequestContext {
     public final SecurityProtocol securityProtocol;
     public final ClientInformation clientInformation;
     public final boolean fromPrivilegedListener;
+    public final Optional<KafkaPrincipalSerde> principalSerde;
 
     public RequestContext(RequestHeader header,
                           String connectionId,
@@ -50,6 +53,26 @@ public class RequestContext implements AuthorizableRequestContext {
                           SecurityProtocol securityProtocol,
                           ClientInformation clientInformation,
                           boolean fromPrivilegedListener) {
+        this(header,
+            connectionId,
+            clientAddress,
+            principal,
+            listenerName,
+            securityProtocol,
+            clientInformation,
+            fromPrivilegedListener,
+            Optional.empty());
+    }
+
+    public RequestContext(RequestHeader header,
+                          String connectionId,
+                          InetAddress clientAddress,
+                          KafkaPrincipal principal,
+                          ListenerName listenerName,
+                          SecurityProtocol securityProtocol,
+                          ClientInformation clientInformation,
+                          boolean fromPrivilegedListener,
+                          Optional<KafkaPrincipalSerde> principalSerde) {
         this.header = header;
         this.connectionId = connectionId;
         this.clientAddress = clientAddress;
@@ -58,6 +81,7 @@ public class RequestContext implements AuthorizableRequestContext {
         this.securityProtocol = securityProtocol;
         this.clientInformation = clientInformation;
         this.fromPrivilegedListener = fromPrivilegedListener;
+        this.principalSerde = principalSerde;
     }
 
     public RequestAndSize parseRequest(ByteBuffer buffer) {

--- a/clients/src/main/resources/common/message/EnvelopeRequest.json
+++ b/clients/src/main/resources/common/message/EnvelopeRequest.json
@@ -23,8 +23,7 @@
   "fields": [
     { "name": "RequestData", "type": "bytes", "versions": "0+", "zeroCopy": true,
       "about": "The embedded request header and data."},
-    { "name": "RequestPrincipal", "type": "bytes", "versions": "0+", "zeroCopy": true,
-      "ignorable": true, "nullableVersions": "0+", "default": "null",
+    { "name": "RequestPrincipal", "type": "bytes", "versions": "0+", "zeroCopy": true, "nullableVersions": "0+",
       "about": "Value of the initial client principal when the request is redirected by a broker." },
     { "name": "ClientHostAddress", "type": "bytes", "versions": "0+",
       "about": "The original client's address in bytes." }

--- a/clients/src/test/java/org/apache/kafka/common/requests/AbstractResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AbstractResponseTest.java
@@ -47,7 +47,7 @@ public class AbstractResponseTest {
         );
 
         CreateTopicsResponse extractedResponse = (CreateTopicsResponse) CreateTopicsResponse.deserializeBody(
-            envelopeResponse.embedResponseData(), header);
+            envelopeResponse.responseData(), header);
         assertEquals(createTopicsResponse.data(), extractedResponse.data());
     }
 }

--- a/core/src/main/scala/kafka/api/ApiVersion.scala
+++ b/core/src/main/scala/kafka/api/ApiVersion.scala
@@ -143,14 +143,14 @@ object ApiVersion {
   def apiVersionsResponse(throttleTimeMs: Int,
                           maxMagic: Byte,
                           latestSupportedFeatures: Features[SupportedVersionRange],
-                          exposeEnvelopeAPI: Boolean): ApiVersionsResponse = {
+                          exposeEnvelopeApi: Boolean): ApiVersionsResponse = {
     apiVersionsResponse(
       throttleTimeMs,
       maxMagic,
       latestSupportedFeatures,
       Features.emptyFinalizedFeatures,
       ApiVersionsResponse.UNKNOWN_FINALIZED_FEATURES_EPOCH,
-      exposeEnvelopeAPI
+      exposeEnvelopeApi
     )
   }
 
@@ -159,11 +159,9 @@ object ApiVersion {
                           latestSupportedFeatures: Features[SupportedVersionRange],
                           finalizedFeatures: Features[FinalizedVersionRange],
                           finalizedFeaturesEpoch: Long,
-                          exposeEnvelopeAPI: Boolean = false): ApiVersionsResponse = {
-    // If we bump any forwarding RPC in the future, we would add filtering logic
-    // to default API key version ranges.
+                          exposeEnvelopeApi: Boolean): ApiVersionsResponse = {
     val apiKeys = ApiVersionsResponse.defaultApiKeys(maxMagic)
-    if (!exposeEnvelopeAPI) {
+    if (!exposeEnvelopeApi) {
       apiKeys.remove(apiKeys.find(ApiKeys.ENVELOPE.id))
     }
 

--- a/core/src/main/scala/kafka/network/SocketServer.scala
+++ b/core/src/main/scala/kafka/network/SocketServer.scala
@@ -20,8 +20,7 @@ package kafka.network
 import java.io.IOException
 import java.net._
 import java.nio.ByteBuffer
-import java.nio.channels._
-import java.nio.channels.{Selector => NSelector}
+import java.nio.channels.{Selector => NSelector, _}
 import java.util
 import java.util.Optional
 import java.util.concurrent._
@@ -29,32 +28,31 @@ import java.util.concurrent.atomic._
 
 import kafka.cluster.{BrokerEndPoint, EndPoint}
 import kafka.metrics.KafkaMetricsGroup
-import kafka.network
-import kafka.network.RequestChannel.{CloseConnectionResponse, EndThrottlingResponse, EnvelopeContext, NoOpResponse, SendResponse, StartThrottlingResponse}
 import kafka.network.Processor._
+import kafka.network.RequestChannel.{CloseConnectionResponse, EndThrottlingResponse, NoOpResponse, SendResponse, StartThrottlingResponse}
 import kafka.network.SocketServer._
 import kafka.security.CredentialProvider
 import kafka.server.{BrokerReconfigurable, KafkaConfig}
-import kafka.utils._
 import kafka.utils.Implicits._
+import kafka.utils._
 import org.apache.kafka.common.config.ConfigException
 import org.apache.kafka.common.errors.InvalidRequestException
-import org.apache.kafka.common.{Endpoint, KafkaException, MetricName, Reconfigurable}
 import org.apache.kafka.common.memory.{MemoryPool, SimpleMemoryPool}
 import org.apache.kafka.common.metrics._
 import org.apache.kafka.common.metrics.stats.{Avg, CumulativeSum, Meter, Rate}
-import org.apache.kafka.common.network.{ChannelBuilder, ChannelBuilders, ClientInformation, KafkaChannel, ListenerName, ListenerReconfigurable, NetworkReceive, Selectable, Send, Selector => KSelector}
 import org.apache.kafka.common.network.KafkaChannel.ChannelMuteEvent
-import org.apache.kafka.common.protocol.ApiKeys
-import org.apache.kafka.common.requests.{ApiVersionsRequest, EnvelopeRequest, RequestContext, RequestHeader}
-import org.apache.kafka.common.security.auth.{KafkaPrincipalSerde, SecurityProtocol}
+import org.apache.kafka.common.network.{ChannelBuilder, ChannelBuilders, ClientInformation, KafkaChannel, ListenerName, ListenerReconfigurable, Selectable, Send, Selector => KSelector}
+import org.apache.kafka.common.protocol.{ApiKeys, Errors}
+import org.apache.kafka.common.requests.{ApiVersionsRequest, EnvelopeRequest, EnvelopeResponse, RequestContext, RequestHeader}
+import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.utils.{KafkaThread, LogContext, Time}
+import org.apache.kafka.common.{Endpoint, KafkaException, MetricName, Reconfigurable}
 import org.slf4j.event.Level
 
 import scala.collection._
-import scala.jdk.CollectionConverters._
 import scala.collection.mutable.{ArrayBuffer, Buffer}
 import scala.compat.java8.OptionConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.control.ControlThrowable
 
 /**
@@ -975,28 +973,39 @@ private[kafka] class Processor(val id: Int,
                   channel.principal, listenerName, securityProtocol,
                   channel.channelMetadataRegistry.clientInformation, isPrivilegedListener)
 
-                val req =
-                  if (header.apiKey == ApiKeys.ENVELOPE) {
-                    parseEnvelopeRequest(receive, nowNanos, connectionId, context, channel.principalSerde.asScala)
-                  } else {
-                    new RequestChannel.Request(processor = id, context = context,
-                      startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None,
-                      channel.principalSerde.asScala)
-                  }
+                var req = new RequestChannel.Request(processor = id, context = context,
+                  startTimeNanos = nowNanos, memoryPool, receive.payload, requestChannel.metrics, None)
 
-                // KIP-511: ApiVersionsRequest is intercepted here to catch the client software name
-                // and version. It is done here to avoid wiring things up to the api layer.
-                if (header.apiKey == ApiKeys.API_VERSIONS) {
-                  val apiVersionsRequest = req.body[ApiVersionsRequest]
-                  if (apiVersionsRequest.isValid) {
-                    channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
-                      apiVersionsRequest.data.clientSoftwareName,
-                      apiVersionsRequest.data.clientSoftwareVersion))
+                if (req.header.apiKey == ApiKeys.ENVELOPE) {
+                  // Override the request context with the forwarded request context.
+                  // The envelope's context will be preserved in the forwarded context
+
+                  req = parseForwardedPrincipal(req, channel.principalSerde.asScala) match {
+                    case Some(forwardedPrincipal) =>
+                      buildForwardedRequestContext(req, forwardedPrincipal)
+
+                    case None =>
+                      val envelopeResponse = new EnvelopeResponse(Errors.PRINCIPAL_DESERIALIZATION_FAILURE)
+                      sendEnvelopeResponse(req, envelopeResponse)
+                      null
                   }
                 }
-                requestChannel.sendRequest(req)
-                selector.mute(connectionId)
-                handleChannelMuteEvent(connectionId, ChannelMuteEvent.REQUEST_RECEIVED)
+
+                if (req != null) {
+                  // KIP-511: ApiVersionsRequest is intercepted here to catch the client software name
+                  // and version. It is done here to avoid wiring things up to the api layer.
+                  if (header.apiKey == ApiKeys.API_VERSIONS) {
+                    val apiVersionsRequest = req.body[ApiVersionsRequest]
+                    if (apiVersionsRequest.isValid) {
+                      channel.channelMetadataRegistry.registerClientInformation(new ClientInformation(
+                        apiVersionsRequest.data.clientSoftwareName,
+                        apiVersionsRequest.data.clientSoftwareVersion))
+                    }
+                  }
+                  requestChannel.sendRequest(req)
+                  selector.mute(connectionId)
+                  handleChannelMuteEvent(connectionId, ChannelMuteEvent.REQUEST_RECEIVED)
+                }
               }
             }
           case None =>
@@ -1013,32 +1022,64 @@ private[kafka] class Processor(val id: Int,
     selector.clearCompletedReceives()
   }
 
-  private def parseEnvelopeRequest(receive: NetworkReceive,
-                                   nowNanos: Long,
-                                   connectionId: String,
-                                   context: RequestContext,
-                                   principalSerde: Option[KafkaPrincipalSerde]) = {
-    val envelopeRequest = context.parseRequest(receive.payload).request.asInstanceOf[EnvelopeRequest]
+  private def sendEnvelopeResponse(
+    envelopeRequest: RequestChannel.Request,
+    envelopeResponse: EnvelopeResponse
+  ): Unit = {
+    val envelopResponseSend = envelopeRequest.context.buildResponse(envelopeResponse)
+    enqueueResponse(new RequestChannel.SendResponse(
+      envelopeRequest,
+      envelopResponseSend,
+      None,
+      None
+    ))
+  }
 
-    val originalHeader = RequestHeader.parse(envelopeRequest.requestData)
-    // Leave the principal null here is ok since we will fail the request during Kafka API handling.
-    val originalPrincipal = if (principalSerde.isDefined)
-      principalSerde.get.deserialize(envelopeRequest.principalData)
-    else
-      null
+  private def parseForwardedPrincipal(
+    envelopeRequest: RequestChannel.Request,
+    principalSerde: Option[KafkaPrincipalSerde]
+  ): Option[KafkaPrincipal] = {
+    val envelope = envelopeRequest.body[EnvelopeRequest]
+    try {
+      principalSerde.map { serde =>
+        serde.deserialize(envelope.principalData.duplicate())
+      }
+    } catch {
+      case e: Exception =>
+        warn(s"Failed to deserialize principal from envelope request $envelope", e)
+        None
+    }
+  }
 
-    val originalClientAddress = InetAddress.getByAddress(envelopeRequest.clientAddress)
-    val originalContext = new RequestContext(originalHeader, connectionId,
-      originalClientAddress, originalPrincipal, listenerName,
-      securityProtocol, context.clientInformation, isPrivilegedListener)
+  private def buildForwardedRequestContext(
+    envelopeRequest: RequestChannel.Request,
+    forwardedPrincipal: KafkaPrincipal
+  ): RequestChannel.Request = {
+    val envelope = envelopeRequest.body[EnvelopeRequest]
+    val forwardedRequestBuffer = envelope.requestData.duplicate()
+    val forwardedHeader = parseRequestHeader(forwardedRequestBuffer)
+    val forwardedClientAddress = InetAddress.getByAddress(envelope.clientAddress)
 
-    val envelopeContext = new EnvelopeContext(
-      brokerContext = context,
-      receive.payload)
+    val forwardedContext = new RequestContext(
+      forwardedHeader,
+      envelopeRequest.context.connectionId,
+      forwardedClientAddress,
+      forwardedPrincipal,
+      listenerName,
+      securityProtocol,
+      ClientInformation.EMPTY,
+      isPrivilegedListener
+    )
 
-    new network.RequestChannel.Request(processor = id, context = originalContext,
-      startTimeNanos = nowNanos, memoryPool, envelopeRequest.requestData, requestChannel.metrics,
-      Option(envelopeContext), principalSerde)
+    new RequestChannel.Request(
+      processor = id,
+      context = forwardedContext,
+      startTimeNanos = envelopeRequest.startTimeNanos,
+      memoryPool,
+      forwardedRequestBuffer,
+      requestChannel.metrics,
+      Some(envelopeRequest)
+    )
   }
 
   private def processCompletedSends(): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -352,7 +352,7 @@ object KafkaConfig {
   val RequestTimeoutMsProp = CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG
   val ConnectionSetupTimeoutMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MS_CONFIG
   val ConnectionSetupTimeoutMaxMsProp = CommonClientConfigs.SOCKET_CONNECTION_SETUP_TIMEOUT_MAX_MS_CONFIG
-  private[server] val enableMetadataQuorumProp = "enable.metadata.quorum"
+  val EnableMetadataQuorumProp = "enable.metadata.quorum"
 
   /************* Authorizer Configuration ***********/
   val AuthorizerClassNameProp = "authorizer.class.name"
@@ -1027,7 +1027,7 @@ object KafkaConfig {
       .define(RequestTimeoutMsProp, INT, Defaults.RequestTimeoutMs, HIGH, RequestTimeoutMsDoc)
       .define(ConnectionSetupTimeoutMsProp, LONG, Defaults.ConnectionSetupTimeoutMs, MEDIUM, ConnectionSetupTimeoutMsDoc)
       .define(ConnectionSetupTimeoutMaxMsProp, LONG, Defaults.ConnectionSetupTimeoutMaxMs, MEDIUM, ConnectionSetupTimeoutMaxMsDoc)
-      .defineInternal(enableMetadataQuorumProp, BOOLEAN, false, LOW) // The flag to turn on KIP-500 mode to use metadata quorum instead of Zookeeper
+      .defineInternal(EnableMetadataQuorumProp, BOOLEAN, false, LOW) // The flag to turn on KIP-500 mode to use metadata quorum instead of Zookeeper
 
       /************* Authorizer Configuration ***********/
       .define(AuthorizerClassNameProp, STRING, Defaults.AuthorizerClassName, LOW, AuthorizerClassNameDoc)
@@ -1562,7 +1562,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def isFeatureVersioningSupported = interBrokerProtocolVersion >= KAFKA_2_7_IV0
 
   /** ********* Forwarding configuration ***********/
-  def forwardingEnabled = getBoolean(KafkaConfig.enableMetadataQuorumProp)
+  def forwardingEnabled = getBoolean(KafkaConfig.EnableMetadataQuorumProp)
 
   /** ********* Group coordinator configuration ***********/
   val groupMinSessionTimeoutMs = getInt(KafkaConfig.GroupMinSessionTimeoutMsProp)

--- a/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
+++ b/core/src/test/scala/unit/kafka/api/ApiVersionTest.scala
@@ -24,8 +24,8 @@ import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.record.{RecordBatch, RecordVersion}
 import org.apache.kafka.common.requests.{AbstractResponse, ApiVersionsResponse}
 import org.apache.kafka.common.utils.Utils
-import org.junit.Test
 import org.junit.Assert._
+import org.junit.Test
 
 import scala.jdk.CollectionConverters._
 
@@ -172,79 +172,12 @@ class ApiVersionTest {
   }
 
   @Test
-  def testInterBrokerProtocolVersionConstraint(): Unit = {
-    val response = ApiVersion.apiVersionsResponse(
-      10,
-      RecordBatch.MAGIC_VALUE_V2,
-      Features.emptySupportedFeatures(),
-      exposeEnvelopeAPI = false
-    )
-    response.data.apiKeys().forEach(
-      version => {
-        val apiKeys = ApiKeys.forId(version.apiKey())
-        apiKeys match {
-          case ApiKeys.ALTER_CONFIGS =>
-            verifyIBPVersionConstraint(apiKeys, 1)
-
-          case ApiKeys.INCREMENTAL_ALTER_CONFIGS =>
-            verifyIBPVersionConstraint(apiKeys, 1)
-
-          case ApiKeys.ALTER_CLIENT_QUOTAS =>
-            verifyIBPVersionConstraint(apiKeys, 0)
-
-          case ApiKeys.CREATE_ACLS =>
-            verifyIBPVersionConstraint(apiKeys, 2)
-
-          case ApiKeys.DELETE_ACLS =>
-            verifyIBPVersionConstraint(apiKeys, 2)
-
-          case ApiKeys.CREATE_DELEGATION_TOKEN =>
-            verifyIBPVersionConstraint(apiKeys, 2)
-
-          case ApiKeys.RENEW_DELEGATION_TOKEN =>
-            verifyIBPVersionConstraint(apiKeys, 2)
-
-          case ApiKeys.EXPIRE_DELEGATION_TOKEN =>
-            verifyIBPVersionConstraint(apiKeys, 2)
-
-          case ApiKeys.ALTER_PARTITION_REASSIGNMENTS =>
-            verifyIBPVersionConstraint(apiKeys, 0)
-
-          case ApiKeys.CREATE_PARTITIONS =>
-            verifyIBPVersionConstraint(apiKeys, 3)
-
-          case ApiKeys.CREATE_TOPICS =>
-            verifyIBPVersionConstraint(apiKeys, 6)
-
-          case ApiKeys.DELETE_TOPICS =>
-            verifyIBPVersionConstraint(apiKeys, 5)
-
-          case ApiKeys.UPDATE_FEATURES =>
-            verifyIBPVersionConstraint(apiKeys, 0)
-
-          case ApiKeys.ALTER_USER_SCRAM_CREDENTIALS =>
-            verifyIBPVersionConstraint(apiKeys, 0)
-
-          case _ =>
-        }
-      }
-    )
-  }
-
-  private def verifyIBPVersionConstraint(apiKeys: ApiKeys, expectedVersion: Short): Unit = {
-    assertEquals(s"The latest version of RPC $apiKeys does not match " +
-      s"expected version $expectedVersion. If you recently " +
-      s"bumped this RPC version, you should also bump IBP and update this test correspondingly.",
-      expectedVersion, apiKeys.latestVersion())
-  }
-
-  @Test
   def shouldCreateApiResponseOnlyWithKeysSupportedByMagicValue(): Unit = {
     val response = ApiVersion.apiVersionsResponse(
       10,
       RecordBatch.MAGIC_VALUE_V1,
       Features.emptySupportedFeatures,
-      exposeEnvelopeAPI = false
+      exposeEnvelopeApi = false
     )
     verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1)
     assertEquals(10, response.throttleTimeMs)
@@ -262,7 +195,8 @@ class ApiVersionTest {
         Utils.mkMap(Utils.mkEntry("feature", new SupportedVersionRange(1.toShort, 4.toShort)))),
       Features.finalizedFeatures(
         Utils.mkMap(Utils.mkEntry("feature", new FinalizedVersionRange(2.toShort, 3.toShort)))),
-      10
+      10,
+      false
     )
 
     verifyApiKeysForMagic(response, RecordBatch.MAGIC_VALUE_V1)
@@ -292,7 +226,7 @@ class ApiVersionTest {
       AbstractResponse.DEFAULT_THROTTLE_TIME,
       RecordBatch.CURRENT_MAGIC_VALUE,
       Features.emptySupportedFeatures,
-      exposeEnvelopeAPI = true
+      exposeEnvelopeApi = true
     )
     assertEquals(new util.HashSet[ApiKeys](ApiKeys.enabledApis), apiKeysInResponse(response))
     assertEquals(AbstractResponse.DEFAULT_THROTTLE_TIME, response.throttleTimeMs)
@@ -307,7 +241,7 @@ class ApiVersionTest {
       AbstractResponse.DEFAULT_THROTTLE_TIME,
       RecordBatch.CURRENT_MAGIC_VALUE,
       Features.emptySupportedFeatures,
-      exposeEnvelopeAPI = false
+      exposeEnvelopeApi = false
     )
 
     val expectedApiKeys = ApiKeys.enabledApis

--- a/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaApisTest.scala
@@ -22,22 +22,18 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.util
 import java.util.Arrays.asList
-import java.util.{Collections, Optional, Random}
 import java.util.concurrent.TimeUnit
+import java.util.{Collections, Optional, Random}
 
 import kafka.api.{ApiVersion, KAFKA_0_10_2_IV0, KAFKA_2_2_IV1, LeaderAndIsr}
 import kafka.cluster.Partition
 import kafka.controller.KafkaController
-import kafka.coordinator.group.GroupOverview
-import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.JoinGroupCallback
-import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.SyncGroupCallback
-import kafka.coordinator.group.JoinGroupResult
-import kafka.coordinator.group.SyncGroupResult
-import kafka.coordinator.group.{GroupCoordinator, GroupSummary, MemberSummary}
+import kafka.coordinator.group.GroupCoordinatorConcurrencyTest.{JoinGroupCallback, SyncGroupCallback}
+import kafka.coordinator.group.{GroupCoordinator, GroupOverview, GroupSummary, JoinGroupResult, MemberSummary, SyncGroupResult}
 import kafka.coordinator.transaction.{InitProducerIdResult, TransactionCoordinator}
 import kafka.log.AppendOrigin
 import kafka.network.RequestChannel
-import kafka.network.RequestChannel.{CloseConnectionResponse, EnvelopeContext, SendResponse}
+import kafka.network.RequestChannel.{CloseConnectionResponse, SendResponse}
 import kafka.server.QuotaFactory.QuotaManagers
 import kafka.utils.{MockTime, TestUtils}
 import kafka.zk.KafkaZkClient
@@ -46,7 +42,6 @@ import org.apache.kafka.clients.admin.AlterConfigOp.OpType
 import org.apache.kafka.clients.admin.{AlterConfigOp, ConfigEntry}
 import org.apache.kafka.common.acl.AclOperation
 import org.apache.kafka.common.config.ConfigResource
-import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition}
 import org.apache.kafka.common.errors.UnsupportedVersionException
 import org.apache.kafka.common.internals.{KafkaFutureImpl, Topic}
 import org.apache.kafka.common.memory.MemoryPool
@@ -70,16 +65,16 @@ import org.apache.kafka.common.requests.{FetchMetadata => JFetchMetadata, _}
 import org.apache.kafka.common.resource.{PatternType, Resource, ResourcePattern, ResourceType}
 import org.apache.kafka.common.security.auth.{KafkaPrincipal, KafkaPrincipalSerde, SecurityProtocol}
 import org.apache.kafka.common.utils.ProducerIdAndEpoch
-import org.apache.kafka.server.authorizer.Action
-import org.apache.kafka.server.authorizer.AuthorizationResult
-import org.apache.kafka.server.authorizer.Authorizer
+import org.apache.kafka.common.{IsolationLevel, Node, TopicPartition}
+import org.apache.kafka.server.authorizer.{Action, AuthorizationResult, Authorizer}
 import org.easymock.EasyMock._
 import org.easymock.{Capture, EasyMock, IAnswer, IArgumentMatcher}
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertNull, assertTrue}
 import org.junit.{After, Test}
 
-import scala.jdk.CollectionConverters._
 import scala.collection.{Map, Seq, mutable}
+import scala.compat.java8.OptionConverters._
+import scala.jdk.CollectionConverters._
 
 class KafkaApisTest {
 
@@ -322,25 +317,17 @@ class KafkaApisTest {
       configResource -> new AlterConfigsRequest.Config(
         Seq(new AlterConfigsRequest.ConfigEntry("foo", "bar")).asJava))
     val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false).build(requestHeader.apiVersion)
-    val serializedRequestData = alterConfigsRequest.serialize(requestHeader)
 
-    val envelopeHeader = new RequestHeader(ApiKeys.ENVELOPE, ApiKeys.ENVELOPE.latestVersion,
-      clientId, 0)
-    val envelopeRequest = new EnvelopeRequest.Builder(serializedRequestData, null, hostAddress)
-      .build(envelopeHeader.apiVersion)
-    val request = buildRequestWithEnvelopeContext(alterConfigsRequest,
-      fromPrivilegedListener = true,
-      requestHeader = Option(requestHeader),
-      principalSerde = kafkaPrincipalSerde,
-      envelopeHeader = envelopeHeader)
+    val request = buildRequestWithEnvelope(alterConfigsRequest, fromPrivilegedListener = true)
     createKafkaApis(authorizer = Some(authorizer), enableForwarding = true).handle(request)
 
-    val response = readResponse(ApiKeys.ENVELOPE, envelopeRequest, capturedResponse)
+    val envelopeRequest = request.envelope.get.body[EnvelopeRequest]
+    val response = readResponse(envelopeRequest, capturedResponse)
       .asInstanceOf[EnvelopeResponse]
 
     assertEquals(Errors.NONE, response.error)
 
-    val innerResponse = AbstractResponse.deserializeBody(response.embedResponseData(),
+    val innerResponse = AbstractResponse.deserializeBody(response.responseData(),
       requestHeader).asInstanceOf[AlterConfigsResponse]
 
     val responseMap = innerResponse.data.responses().asScala.map { resourceResponse =>
@@ -370,11 +357,11 @@ class KafkaApisTest {
 
     val envelopeRequest = new EnvelopeRequest.Builder(serializedRequestData, null, hostAddress)
       .build(ApiKeys.ENVELOPE.latestVersion)
-    val request = buildRequest(envelopeRequest, fromPrivilegedListener = true, principalSerde = kafkaPrincipalSerde)
+    val request = buildRequest(envelopeRequest, fromPrivilegedListener = true)
 
     createKafkaApis(enableForwarding = true).handle(request)
 
-    val response = readResponse(ApiKeys.ENVELOPE, envelopeRequest, capturedResponse)
+    val response = readResponse(envelopeRequest, capturedResponse)
       .asInstanceOf[EnvelopeResponse]
     assertEquals(Errors.UNKNOWN_SERVER_ERROR, response.error())
   }
@@ -396,22 +383,13 @@ class KafkaApisTest {
 
     val envelopeRequest = new EnvelopeRequest.Builder(serializedRequestData, null, hostAddress)
       .build(envelopeHeader.apiVersion)
-    val request = buildRequestWithEnvelopeContext(leaveGroupRequest,
-      fromPrivilegedListener = true,
-      requestHeader = Option(requestHeader),
-      principalSerde = kafkaPrincipalSerde,
-      envelopeHeader = envelopeHeader)
+    val request = buildRequestWithEnvelope(leaveGroupRequest, fromPrivilegedListener = true)
 
     createKafkaApis(enableForwarding = true).handle(request)
 
-    val response = readResponse(ApiKeys.ENVELOPE, envelopeRequest, capturedResponse)
+    val response = readResponse(envelopeRequest, capturedResponse)
       .asInstanceOf[EnvelopeResponse]
     assertEquals(Errors.INVALID_REQUEST, response.error())
-  }
-
-  @Test
-  def testEnvelopeRequestWithNoPrincipalSerde(): Unit = {
-    testInvalidEnvelopeRequest(Errors.PRINCIPAL_DESERIALIZATION_FAILURE, principalSerde = None, performAuthorize = true)
   }
 
   @Test
@@ -459,25 +437,18 @@ class KafkaApisTest {
     val configs = Map(
       configResource -> new AlterConfigsRequest.Config(
         Seq(new AlterConfigsRequest.ConfigEntry("foo", "bar")).asJava))
-    val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false).build(requestHeader.apiVersion)
+    val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false)
+      .build(requestHeader.apiVersion)
 
-    val envelopeHeader = new RequestHeader(ApiKeys.ENVELOPE, ApiKeys.ENVELOPE.latestVersion,
-      clientId, 0)
-    val serializedRequestData = alterConfigsRequest.serialize(requestHeader)
-
-    val envelopeRequest = new EnvelopeRequest.Builder(serializedRequestData, null, hostAddress)
-      .build(envelopeHeader.apiVersion)
-    val request = buildRequestWithEnvelopeContext(alterConfigsRequest,
-      fromPrivilegedListener = fromPrivilegedListener,
-      requestHeader = Option(requestHeader),
-      principalSerde = principalSerde,
-      envelopeHeader = envelopeHeader)
+    val request = buildRequestWithEnvelope(alterConfigsRequest,
+      fromPrivilegedListener = fromPrivilegedListener)
     createKafkaApis(authorizer = Some(authorizer), enableForwarding = true).handle(request)
 
     if (shouldCloseConnection) {
       assertTrue(capturedResponse.getValue.isInstanceOf[CloseConnectionResponse])
     } else {
-      val response = readResponse(ApiKeys.ENVELOPE, envelopeRequest, capturedResponse)
+      val envelopeRequest = request.envelope.get.body[EnvelopeRequest]
+      val response = readResponse(envelopeRequest, capturedResponse)
         .asInstanceOf[EnvelopeResponse]
 
       assertEquals(expectedError, response.error())
@@ -549,7 +520,7 @@ class KafkaApisTest {
 
     val alterConfigsRequest = new AlterConfigsRequest.Builder(configs.asJava, false)
       .build(topicHeader.apiVersion)
-    val request = buildRequest(alterConfigsRequest, principalSerde = kafkaPrincipalSerde)
+    val request = buildRequest(alterConfigsRequest)
 
     EasyMock.expect(controller.isActive).andReturn(false)
 
@@ -570,8 +541,8 @@ class KafkaApisTest {
     EasyMock.expect(clientResponse.responseBody).andReturn(alterConfigsResponse)
 
     EasyMock.expect(forwardingManager.forwardRequest(
-      anyObject[(RequestChannel.Request, Int => AbstractResponse) => Unit](),
-      EasyMock.eq(request)
+      EasyMock.eq(request),
+      anyObject[AbstractResponse => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel,
@@ -606,7 +577,7 @@ class KafkaApisTest {
   private def verifyAlterConfigResult(alterConfigsRequest: AlterConfigsRequest,
                                       capturedResponse: Capture[RequestChannel.Response],
                                       expectedResults: Map[String, Errors]): Unit = {
-    val response = readResponse(ApiKeys.ALTER_CONFIGS, alterConfigsRequest, capturedResponse)
+    val response = readResponse(alterConfigsRequest, capturedResponse)
       .asInstanceOf[AlterConfigsResponse]
     val responseMap = response.data.responses().asScala.map { resourceResponse =>
       resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
@@ -680,7 +651,7 @@ class KafkaApisTest {
     val incrementalAlterConfigsRequest = getIncrementalAlterConfigRequestBuilder(
       Seq(authorizedResource, unauthorizedResource))
       .build(topicHeader.apiVersion)
-    val request = buildRequest(incrementalAlterConfigsRequest, principalSerde = kafkaPrincipalSerde)
+    val request = buildRequest(incrementalAlterConfigsRequest)
 
     val clientResponse: ClientResponse = EasyMock.createNiceMock(classOf[ClientResponse])
 
@@ -697,8 +668,8 @@ class KafkaApisTest {
     EasyMock.expect(clientResponse.responseBody).andReturn(incrementalAlterConfigsResponse)
 
     EasyMock.expect(forwardingManager.forwardRequest(
-      anyObject[(RequestChannel.Request, Int => AbstractResponse) => Unit](),
-      EasyMock.eq(request)
+      EasyMock.eq(request),
+      anyObject[AbstractResponse => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel,
@@ -722,8 +693,7 @@ class KafkaApisTest {
   private def verifyIncrementalAlterConfigResult(incrementalAlterConfigsRequest: IncrementalAlterConfigsRequest,
                                                  capturedResponse: Capture[RequestChannel.Response],
                                                  expectedResults: Map[String, Errors]): Unit = {
-    val response = readResponse(ApiKeys.INCREMENTAL_ALTER_CONFIGS,
-      incrementalAlterConfigsRequest, capturedResponse)
+    val response = readResponse(incrementalAlterConfigsRequest, capturedResponse)
       .asInstanceOf[IncrementalAlterConfigsResponse]
     val responseMap = response.data.responses().asScala.map { resourceResponse =>
       resourceResponse.resourceName() -> Errors.forCode(resourceResponse.errorCode)
@@ -778,15 +748,15 @@ class KafkaApisTest {
       clientId, 0)
 
     val request = buildRequest(new AlterClientQuotasRequest.Builder(quotas.asJavaCollection, false)
-      .build(requestHeader.apiVersion), principalSerde = kafkaPrincipalSerde)
+      .build(requestHeader.apiVersion))
 
     EasyMock.expect(controller.isActive).andReturn(false)
 
     expectNoThrottling()
 
     EasyMock.expect(forwardingManager.forwardRequest(
-      anyObject[(RequestChannel.Request, Int => AbstractResponse) => Unit](),
-      EasyMock.eq(request)
+      EasyMock.eq(request),
+      anyObject[AbstractResponse => Unit](),
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel,
@@ -800,7 +770,7 @@ class KafkaApisTest {
   private def verifyAlterClientQuotaResult(alterClientQuotasRequest: AlterClientQuotasRequest,
                                            capturedResponse: Capture[RequestChannel.Response],
                                            expected: Map[ClientQuotaEntity, Errors]): Unit = {
-    val response = readResponse(ApiKeys.ALTER_CLIENT_QUOTAS, alterClientQuotasRequest, capturedResponse)
+    val response = readResponse(alterClientQuotasRequest, capturedResponse)
       .asInstanceOf[AlterClientQuotasResponse]
     val futures = expected.keys.map(quotaEntity => quotaEntity -> new KafkaFutureImpl[Void]()).toMap
     response.complete(futures.asJava)
@@ -916,7 +886,7 @@ class KafkaApisTest {
         .setValidateOnly(false)
         .setTopics(topics))
       .build(requestHeader.apiVersion)
-    val request = buildRequest(createTopicsRequest, principalSerde = kafkaPrincipalSerde)
+    val request = buildRequest(createTopicsRequest)
 
     val clientResponse: ClientResponse = EasyMock.createNiceMock(classOf[ClientResponse])
 
@@ -932,8 +902,8 @@ class KafkaApisTest {
     EasyMock.expect(clientResponse.responseBody).andReturn(createTopicsResponse)
 
     EasyMock.expect(forwardingManager.forwardRequest(
-      anyObject[(RequestChannel.Request, Int => AbstractResponse) => Unit](),
-      EasyMock.eq(request)
+      EasyMock.eq(request),
+      anyObject[AbstractResponse => Unit]()
     )).once()
 
     EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel,
@@ -986,7 +956,7 @@ class KafkaApisTest {
   private def verifyCreateTopicsResult(createTopicsRequest: CreateTopicsRequest,
                                        capturedResponse: Capture[RequestChannel.Response],
                                        expectedResults: Map[String, Errors]): Unit = {
-    val response = readResponse(ApiKeys.CREATE_TOPICS, createTopicsRequest, capturedResponse)
+    val response = readResponse(createTopicsRequest, capturedResponse)
       .asInstanceOf[CreateTopicsResponse]
     val responseMap = response.data.topics().asScala.map { topicResponse =>
       topicResponse.name() -> Errors.forCode(topicResponse.errorCode)
@@ -1023,7 +993,7 @@ class KafkaApisTest {
       EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)
       createKafkaApis().handleOffsetCommitRequest(request)
 
-      val response = readResponse(ApiKeys.OFFSET_COMMIT, offsetCommitRequest, capturedResponse)
+      val response = readResponse(offsetCommitRequest, capturedResponse)
         .asInstanceOf[OffsetCommitResponse]
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION,
         Errors.forCode(response.data().topics().get(0).partitions().get(0).errorCode()))
@@ -1057,7 +1027,7 @@ class KafkaApisTest {
       EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)
       createKafkaApis().handleTxnOffsetCommitRequest(request)
 
-      val response = readResponse(ApiKeys.TXN_OFFSET_COMMIT, offsetCommitRequest, capturedResponse)
+      val response = readResponse(offsetCommitRequest, capturedResponse)
         .asInstanceOf[TxnOffsetCommitResponse]
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.errors().get(invalidTopicPartition))
     }
@@ -1112,7 +1082,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleTxnOffsetCommitRequest(request)
 
-      val response = readResponse(ApiKeys.TXN_OFFSET_COMMIT, offsetCommitRequest, capturedResponse)
+      val response = readResponse(offsetCommitRequest, capturedResponse)
         .asInstanceOf[TxnOffsetCommitResponse]
 
       if (version < 2) {
@@ -1177,7 +1147,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleInitProducerIdRequest(request)
 
-      val response = readResponse(ApiKeys.INIT_PRODUCER_ID, initProducerIdRequest, capturedResponse)
+      val response = readResponse(initProducerIdRequest, capturedResponse)
         .asInstanceOf[InitProducerIdResponse]
 
       if (version < 4) {
@@ -1234,7 +1204,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleAddOffsetsToTxnRequest(request)
 
-      val response = readResponse(ApiKeys.ADD_OFFSETS_TO_TXN, addOffsetsToTxnRequest, capturedResponse)
+      val response = readResponse(addOffsetsToTxnRequest, capturedResponse)
         .asInstanceOf[AddOffsetsToTxnResponse]
 
       if (version < 2) {
@@ -1288,7 +1258,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleAddPartitionToTxnRequest(request)
 
-      val response = readResponse(ApiKeys.ADD_PARTITIONS_TO_TXN, addPartitionsToTxnRequest, capturedResponse)
+      val response = readResponse(addPartitionsToTxnRequest, capturedResponse)
         .asInstanceOf[AddPartitionsToTxnResponse]
 
       if (version < 2) {
@@ -1339,7 +1309,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleEndTxnRequest(request)
 
-      val response = readResponse(ApiKeys.END_TXN, endTxnRequest, capturedResponse)
+      val response = readResponse(endTxnRequest, capturedResponse)
         .asInstanceOf[EndTxnResponse]
 
       if (version < 2) {
@@ -1368,7 +1338,7 @@ class KafkaApisTest {
       EasyMock.replay(replicaManager, clientRequestQuotaManager, requestChannel)
       createKafkaApis().handleAddPartitionToTxnRequest(request)
 
-      val response = readResponse(ApiKeys.ADD_PARTITIONS_TO_TXN, addPartitionsToTxnRequest, capturedResponse)
+      val response = readResponse(addPartitionsToTxnRequest, capturedResponse)
         .asInstanceOf[AddPartitionsToTxnResponse]
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.errors().get(invalidTopicPartition))
     }
@@ -1416,7 +1386,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
-    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+    val markersResponse = readResponse(writeTxnMarkersRequest, capturedResponse)
       .asInstanceOf[WriteTxnMarkersResponse]
     assertEquals(expectedErrors, markersResponse.errors(1))
   }
@@ -1435,7 +1405,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
-    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+    val markersResponse = readResponse(writeTxnMarkersRequest, capturedResponse)
       .asInstanceOf[WriteTxnMarkersResponse]
     assertEquals(expectedErrors, markersResponse.errors(1))
   }
@@ -1470,7 +1440,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
-    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+    val markersResponse = readResponse(writeTxnMarkersRequest, capturedResponse)
       .asInstanceOf[WriteTxnMarkersResponse]
     assertEquals(expectedErrors, markersResponse.errors(1))
     EasyMock.verify(replicaManager)
@@ -1607,7 +1577,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleWriteTxnMarkersRequest(request)
 
-    val markersResponse = readResponse(ApiKeys.WRITE_TXN_MARKERS, writeTxnMarkersRequest, capturedResponse)
+    val markersResponse = readResponse(writeTxnMarkersRequest, capturedResponse)
       .asInstanceOf[WriteTxnMarkersResponse]
     assertEquals(expectedErrors, markersResponse.errors(1))
     EasyMock.verify(replicaManager)
@@ -1681,7 +1651,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleDescribeGroupRequest(request)
 
-    val response = readResponse(ApiKeys.DESCRIBE_GROUPS, describeGroupsRequest, capturedResponse)
+    val response = readResponse(describeGroupsRequest, capturedResponse)
       .asInstanceOf[DescribeGroupsResponse]
 
     val group = response.data().groups().get(0)
@@ -1748,7 +1718,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleOffsetDeleteRequest(request)
 
-    val response = readResponse(ApiKeys.OFFSET_DELETE, offsetDeleteRequest, capturedResponse)
+    val response = readResponse(offsetDeleteRequest, capturedResponse)
       .asInstanceOf[OffsetDeleteResponse]
 
     def errorForPartition(topic: String, partition: Int): Errors = {
@@ -1790,7 +1760,7 @@ class KafkaApisTest {
 
       createKafkaApis().handleOffsetDeleteRequest(request)
 
-      val response = readResponse(ApiKeys.OFFSET_DELETE, offsetDeleteRequest, capturedResponse)
+      val response = readResponse(offsetDeleteRequest, capturedResponse)
         .asInstanceOf[OffsetDeleteResponse]
 
       assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION,
@@ -1820,7 +1790,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleOffsetDeleteRequest(request)
 
-    val response = readResponse(ApiKeys.OFFSET_DELETE, offsetDeleteRequest, capturedResponse)
+    val response = readResponse(offsetDeleteRequest, capturedResponse)
       .asInstanceOf[OffsetDeleteResponse]
 
     assertEquals(Errors.GROUP_ID_NOT_FOUND, Errors.forCode(response.data.errorCode()))
@@ -1853,7 +1823,7 @@ class KafkaApisTest {
     val request = buildRequest(listOffsetRequest)
     createKafkaApis().handleListOffsetRequest(request)
 
-    val response = readResponse(ApiKeys.LIST_OFFSETS, listOffsetRequest, capturedResponse)
+    val response = readResponse(listOffsetRequest, capturedResponse)
       .asInstanceOf[ListOffsetResponse]
     val partitionDataOptional = response.topics.asScala.find(_.name == tp.topic).get
       .partitions.asScala.find(_.partitionIndex == tp.partition)
@@ -1946,7 +1916,7 @@ class KafkaApisTest {
     val request = buildRequest(fetchRequest)
     createKafkaApis().handleFetchRequest(request)
 
-    val response = readResponse(ApiKeys.FETCH, fetchRequest, capturedResponse)
+    val response = readResponse(fetchRequest, capturedResponse)
       .asInstanceOf[FetchResponse[BaseRecords]]
     assertTrue(response.responseData.containsKey(tp))
 
@@ -2069,7 +2039,7 @@ class KafkaApisTest {
 
     capturedCallback.getValue.apply(JoinGroupResult(memberId, Errors.INCONSISTENT_GROUP_PROTOCOL))
 
-    val response = readResponse(ApiKeys.JOIN_GROUP, joinGroupRequest, capturedResponse)
+    val response = readResponse(joinGroupRequest, capturedResponse)
       .asInstanceOf[JoinGroupResponse]
 
     assertEquals(Errors.INCONSISTENT_GROUP_PROTOCOL, response.error)
@@ -2150,7 +2120,7 @@ class KafkaApisTest {
       error = Errors.NONE
     ))
 
-    val response = readResponse(ApiKeys.JOIN_GROUP, joinGroupRequest, capturedResponse)
+    val response = readResponse(joinGroupRequest, capturedResponse)
       .asInstanceOf[JoinGroupResponse]
 
     assertEquals(Errors.NONE, response.error)
@@ -2223,7 +2193,7 @@ class KafkaApisTest {
       error = Errors.NONE
     ))
 
-    val response = readResponse(ApiKeys.SYNC_GROUP, syncGroupRequest, capturedResponse)
+    val response = readResponse(syncGroupRequest, capturedResponse)
       .asInstanceOf[SyncGroupResponse]
 
     assertEquals(Errors.NONE, response.error)
@@ -2294,7 +2264,7 @@ class KafkaApisTest {
       ))
     }
 
-    val response = readResponse(ApiKeys.SYNC_GROUP, syncGroupRequest, capturedResponse)
+    val response = readResponse(syncGroupRequest, capturedResponse)
       .asInstanceOf[SyncGroupResponse]
 
     if (version < 5) {
@@ -2323,7 +2293,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(joinGroupRequest)
     createKafkaApis(KAFKA_2_2_IV1).handleJoinGroupRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.JOIN_GROUP, joinGroupRequest, capturedResponse).asInstanceOf[JoinGroupResponse]
+    val response = readResponse(joinGroupRequest, capturedResponse).asInstanceOf[JoinGroupResponse]
     assertEquals(Errors.UNSUPPORTED_VERSION, response.error())
     EasyMock.replay(groupCoordinator)
   }
@@ -2344,7 +2314,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(syncGroupRequest)
     createKafkaApis(KAFKA_2_2_IV1).handleSyncGroupRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.SYNC_GROUP, syncGroupRequest, capturedResponse).asInstanceOf[SyncGroupResponse]
+    val response = readResponse(syncGroupRequest, capturedResponse).asInstanceOf[SyncGroupResponse]
     assertEquals(Errors.UNSUPPORTED_VERSION, response.error)
     EasyMock.replay(groupCoordinator)
   }
@@ -2364,7 +2334,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(heartbeatRequest)
     createKafkaApis(KAFKA_2_2_IV1).handleHeartbeatRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.HEARTBEAT, heartbeatRequest, capturedResponse).asInstanceOf[HeartbeatResponse]
+    val response = readResponse(heartbeatRequest, capturedResponse).asInstanceOf[HeartbeatResponse]
     assertEquals(Errors.UNSUPPORTED_VERSION, response.error())
     EasyMock.replay(groupCoordinator)
   }
@@ -2405,7 +2375,7 @@ class KafkaApisTest {
             .setErrorCode(Errors.UNSUPPORTED_VERSION.code())
         ))
     )
-    val response = readResponse(ApiKeys.OFFSET_COMMIT, offsetCommitRequest, capturedResponse).asInstanceOf[OffsetCommitResponse]
+    val response = readResponse(offsetCommitRequest, capturedResponse).asInstanceOf[OffsetCommitResponse]
     assertEquals(expectedTopicErrors, response.data.topics())
     EasyMock.replay(groupCoordinator)
   }
@@ -2547,7 +2517,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(initProducerIdRequest)
     createKafkaApis(KAFKA_2_2_IV1).handleInitProducerIdRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.INIT_PRODUCER_ID, initProducerIdRequest, capturedResponse)
+    val response = readResponse(initProducerIdRequest, capturedResponse)
       .asInstanceOf[InitProducerIdResponse]
     assertEquals(Errors.INVALID_REQUEST, response.error)
   }
@@ -2567,7 +2537,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(initProducerIdRequest)
     createKafkaApis(KAFKA_2_2_IV1).handleInitProducerIdRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.INIT_PRODUCER_ID, initProducerIdRequest, capturedResponse).asInstanceOf[InitProducerIdResponse]
+    val response = readResponse(initProducerIdRequest, capturedResponse).asInstanceOf[InitProducerIdResponse]
     assertEquals(Errors.INVALID_REQUEST, response.error)
   }
 
@@ -2607,7 +2577,7 @@ class KafkaApisTest {
     EasyMock.replay(replicaManager, controller, requestChannel)
 
     createKafkaApis().handleUpdateMetadataRequest(request)
-    val updateMetadataResponse = readResponse(ApiKeys.UPDATE_METADATA, updateMetadataRequest, capturedResponse)
+    val updateMetadataResponse = readResponse(updateMetadataRequest, capturedResponse)
       .asInstanceOf[UpdateMetadataResponse]
     assertEquals(expectedError, updateMetadataResponse.error())
     EasyMock.verify(replicaManager)
@@ -2673,7 +2643,7 @@ class KafkaApisTest {
     EasyMock.replay(replicaManager, controller, requestChannel)
 
     createKafkaApis().handleLeaderAndIsrRequest(request)
-    val leaderAndIsrResponse = readResponse(ApiKeys.LEADER_AND_ISR, leaderAndIsrRequest, capturedResponse)
+    val leaderAndIsrResponse = readResponse(leaderAndIsrRequest, capturedResponse)
       .asInstanceOf[LeaderAndIsrResponse]
     assertEquals(expectedError, leaderAndIsrResponse.error())
     EasyMock.verify(replicaManager)
@@ -2737,7 +2707,7 @@ class KafkaApisTest {
     EasyMock.replay(controller, replicaManager, requestChannel)
 
     createKafkaApis().handleStopReplicaRequest(request)
-    val stopReplicaResponse = readResponse(ApiKeys.STOP_REPLICA, stopReplicaRequest, capturedResponse)
+    val stopReplicaResponse = readResponse(stopReplicaRequest, capturedResponse)
       .asInstanceOf[StopReplicaResponse]
     assertEquals(expectedError, stopReplicaResponse.error())
     EasyMock.verify(replicaManager)
@@ -2782,7 +2752,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleListGroupsRequest(requestChannelRequest)
 
-    val response = readResponse(ApiKeys.LIST_GROUPS, listGroupsRequest, capturedResponse).asInstanceOf[ListGroupsResponse]
+    val response = readResponse(listGroupsRequest, capturedResponse).asInstanceOf[ListGroupsResponse]
     assertEquals(Errors.NONE.code, response.data.errorCode)
     response
   }
@@ -2833,7 +2803,7 @@ class KafkaApisTest {
     val requestChannelRequest = buildRequest(metadataRequest, requestListener)
     createKafkaApis().handleTopicMetadataRequest(requestChannelRequest)
 
-    readResponse(ApiKeys.METADATA, metadataRequest, capturedResponse).asInstanceOf[MetadataResponse]
+    readResponse(metadataRequest, capturedResponse).asInstanceOf[MetadataResponse]
   }
 
   private def testConsumerListOffsetLatest(isolationLevel: IsolationLevel): Unit = {
@@ -2862,7 +2832,7 @@ class KafkaApisTest {
     val request = buildRequest(listOffsetRequest)
     createKafkaApis().handleListOffsetRequest(request)
 
-    val response = readResponse(ApiKeys.LIST_OFFSETS, listOffsetRequest, capturedResponse).asInstanceOf[ListOffsetResponse]
+    val response = readResponse(listOffsetRequest, capturedResponse).asInstanceOf[ListOffsetResponse]
     val partitionDataOptional = response.topics.asScala.find(_.name == tp.topic).get
       .partitions.asScala.find(_.partitionIndex == tp.partition)
     assertTrue(partitionDataOptional.isDefined)
@@ -2880,38 +2850,68 @@ class KafkaApisTest {
     (writeTxnMarkersRequest, buildRequest(writeTxnMarkersRequest))
   }
 
-  private def buildRequestWithEnvelopeContext(request: AbstractRequest,
-                                              listenerName: ListenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
-                                              fromPrivilegedListener: Boolean,
-                                              requestHeader: Option[RequestHeader],
-                                              principalSerde: Option[KafkaPrincipalSerde],
-                                              envelopeHeader: RequestHeader): RequestChannel.Request = {
-    val envelopeContext: Option[EnvelopeContext] = Option(new EnvelopeContext(
-      new RequestContext(envelopeHeader, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
-        listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY,
-        fromPrivilegedListener)
-      , null))
-    buildRequest(request, listenerName, fromPrivilegedListener, requestHeader, principalSerde, envelopeContext)
+  private def buildRequestWithEnvelope(
+    request: AbstractRequest,
+    fromPrivilegedListener: Boolean,
+    principalSerde: Option[KafkaPrincipalSerde] = kafkaPrincipalSerde
+  ): RequestChannel.Request = {
+    val listenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT)
+
+    val requestHeader = new RequestHeader(request.api, request.version, clientId, 0)
+    val requestBuffer = request.serialize(requestHeader)
+    val requestContext = new RequestContext(requestHeader, "1", InetAddress.getLocalHost,
+      KafkaPrincipal.ANONYMOUS, listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY,
+      fromPrivilegedListener)
+
+    val envelopeHeader = new RequestHeader(ApiKeys.ENVELOPE, ApiKeys.ENVELOPE.latestVersion(), clientId, 0)
+    val envelopeBuffer = new EnvelopeRequest.Builder(
+      requestBuffer,
+      InetAddress.getLocalHost.getAddress
+    ).build().serialize(envelopeHeader)
+    val envelopeContext = new RequestContext(envelopeHeader, "1", InetAddress.getLocalHost,
+      KafkaPrincipal.ANONYMOUS, listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY,
+      fromPrivilegedListener, principalSerde.asJava)
+
+    RequestHeader.parse(envelopeBuffer)
+    val envelopeRequest = Some(new RequestChannel.Request(
+      processor = 1,
+      context = envelopeContext,
+      startTimeNanos = time.nanoseconds(),
+      memoryPool = MemoryPool.NONE,
+      buffer = envelopeBuffer,
+      metrics = requestChannelMetrics
+    ))
+
+    RequestHeader.parse(requestBuffer)
+    new RequestChannel.Request(
+      processor = 1,
+      context = requestContext,
+      startTimeNanos = time.nanoseconds(),
+      memoryPool = MemoryPool.NONE,
+      buffer = requestBuffer,
+      metrics = requestChannelMetrics,
+      envelope = envelopeRequest
+    )
   }
 
   private def buildRequest(request: AbstractRequest,
                            listenerName: ListenerName = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT),
                            fromPrivilegedListener: Boolean = false,
-                           requestHeader: Option[RequestHeader] = None,
-                           principalSerde: Option[KafkaPrincipalSerde] = None,
-                           envelopeContext: Option[EnvelopeContext] = None): RequestChannel.Request = {
+                           requestHeader: Option[RequestHeader] = None): RequestChannel.Request = {
     val buffer = request.serialize(requestHeader.getOrElse(
       new RequestHeader(request.api, request.version, clientId, 0)))
 
     // read the header from the buffer first so that the body can be read next from the Request constructor
     val header = RequestHeader.parse(buffer)
     val context = new RequestContext(header, "1", InetAddress.getLocalHost, KafkaPrincipal.ANONYMOUS,
-      listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, fromPrivilegedListener)
+      listenerName, SecurityProtocol.PLAINTEXT, ClientInformation.EMPTY, fromPrivilegedListener,
+      kafkaPrincipalSerde.asJava)
     new RequestChannel.Request(processor = 1, context = context, startTimeNanos = 0, MemoryPool.NONE, buffer,
-      requestChannelMetrics, envelopeContext, principalSerde)
+      requestChannelMetrics, envelope = None)
   }
 
-  private def readResponse(api: ApiKeys, request: AbstractRequest, capturedResponse: Capture[RequestChannel.Response]): AbstractResponse = {
+  private def readResponse(request: AbstractRequest, capturedResponse: Capture[RequestChannel.Response]) = {
+    val api = request.api
     val response = capturedResponse.getValue
     assertTrue(s"Unexpected response type: ${response.getClass}", response.isInstanceOf[SendResponse])
     val sendResponse = response.asInstanceOf[SendResponse]
@@ -2999,7 +2999,7 @@ class KafkaApisTest {
 
     createKafkaApis().handleAlterReplicaLogDirsRequest(request)
 
-    val response = readResponse(ApiKeys.ALTER_REPLICA_LOG_DIRS, alterReplicaLogDirsRequest, capturedResponse)
+    val response = readResponse(alterReplicaLogDirsRequest, capturedResponse)
       .asInstanceOf[AlterReplicaLogDirsResponse]
     assertEquals(partitionResults, response.data.results.asScala.flatMap { tr =>
       tr.partitions().asScala.map { pr =>


### PR DESCRIPTION
Fixes/improves the following:

- Handle serialization errors return by `KafkaPrincipalSerde`
- Ensure throttle time from forward response is enforced
- Principal in envelope should not be ignorable
- Clean up `BrokerToControllerChannelManager` forwarding API
- Retain full envelope request and drop `EnvelopeRequest` for simpler response handling

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
