### PR TITLE
Fix a few lingering problems

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1101,20 +1101,36 @@ class KafkaApis(val requestChannel: RequestChannel,
       .setPartitions(partitionData)
   }
 
-  private def getTopicMetadata(isFetchAllMetadata: Boolean,
-                               topics: Set[String],
-                               listenerName: ListenerName,
-                               errorUnavailableEndpoints: Boolean,
-                               errorUnavailableListeners: Boolean): (Seq[MetadataResponseTopic], Set[String]) = {
+  private def getTopicMetadata(
+    request: RequestChannel.Request,
+    allowAutoTopicCreation: Boolean,
+    topics: Set[String],
+    listenerName: ListenerName,
+    errorUnavailableEndpoints: Boolean,
+    errorUnavailableListeners: Boolean
+  ): Seq[MetadataResponseTopic] = {
     val topicResponses = metadataCache.getTopicMetadata(topics, listenerName,
-        errorUnavailableEndpoints, errorUnavailableListeners)
+      errorUnavailableEndpoints, errorUnavailableListeners)
 
-    // A metadata request for all topics should never result in topic auto creation, but a topic may be deleted
-    // in between the creation of the topics parameter and topicResponses, so make sure to return None for this case.
-    if (isFetchAllMetadata || topics.isEmpty || topicResponses.size == topics.size) {
-      (topicResponses, Set.empty[String])
+    if (topics.isEmpty || topicResponses.size == topics.size) {
+      topicResponses
     } else {
-      (topicResponses, topics.diff(topicResponses.map(_.name).toSet))
+      val nonExistingTopics = topics.diff(topicResponses.map(_.name).toSet)
+      val nonExistingTopicResponses = if (allowAutoTopicCreation) {
+        val controllerMutationQuota = quotas.controllerMutation.newPermissiveQuotaFor(request)
+        autoTopicCreationManager.createTopics(nonExistingTopics, controllerMutationQuota)
+      } else {
+        nonExistingTopics.map { topic =>
+          metadataResponseTopic(
+            Errors.UNKNOWN_TOPIC_OR_PARTITION,
+            topic,
+            Topic.isInternal(topic),
+            util.Collections.emptyList()
+          )
+        }
+      }
+
+      topicResponses ++ nonExistingTopicResponses
     }
   }
 
@@ -1162,20 +1178,10 @@ class KafkaApis(val requestChannel: RequestChannel,
     // In versions 5 and below, we returned LEADER_NOT_AVAILABLE if a matching listener was not found on the leader.
     // From version 6 onwards, we return LISTENER_NOT_FOUND to enable diagnosis of configuration errors.
     val errorUnavailableListeners = requestVersion >= 6
-    val (topicMetadata, nonExistTopics) =
-      if (authorizedTopics.isEmpty)
-        (Seq.empty[MetadataResponseTopic], Set.empty[String])
-      else
-        getTopicMetadata(metadataRequest.isAllTopics, authorizedTopics,
-          request.context.listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
 
-    val nonExistTopicMetadata =
-      if (nonExistTopics.nonEmpty && metadataRequest.allowAutoTopicCreation && config.autoCreateTopicsEnable) {
-        val controllerMutationQuota = quotas.controllerMutation.newQuotaFor(request, strictSinceVersion = 6)
-        autoTopicCreationManager.createTopics(
-          nonExistTopics.toSet, controllerMutationQuota)
-      } else
-        Seq.empty[MetadataResponseTopic]
+    val allowAutoCreation = metadataRequest.allowAutoTopicCreation && !metadataRequest.isAllTopics
+    val topicMetadata = getTopicMetadata(request, allowAutoCreation, authorizedTopics,
+      request.context.listenerName, errorUnavailableEndpoints, errorUnavailableListeners)
 
     var clusterAuthorizedOperations = Int.MinValue // Default value in the schema
     if (requestVersion >= 8) {
@@ -1197,11 +1203,10 @@ class KafkaApis(val requestChannel: RequestChannel,
           }
         }
         setTopicAuthorizedOperations(topicMetadata)
-        setTopicAuthorizedOperations(nonExistTopicMetadata)
       }
     }
 
-    val completeTopicMetadata = topicMetadata ++ nonExistTopicMetadata ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
+    val completeTopicMetadata = topicMetadata ++ unauthorizedForCreateTopicMetadata ++ unauthorizedForDescribeTopicMetadata
 
     val brokers = metadataCache.getAliveBrokers
 
@@ -1331,7 +1336,7 @@ class KafkaApis(val requestChannel: RequestChannel,
       }
 
       if (topicMetadata.headOption.isEmpty) {
-        val controllerMutationQuota = quotas.controllerMutation.newQuotaFor(request, strictSinceVersion = 6)
+        val controllerMutationQuota = quotas.controllerMutation.newPermissiveQuotaFor(request)
         autoTopicCreationManager.createTopics(Seq(internalTopicName).toSet, controllerMutationQuota)
         requestHelper.sendResponseMaybeThrottle(request, requestThrottleMs => createFindCoordinatorResponse(
           Errors.COORDINATOR_NOT_AVAILABLE, Node.noNode, requestThrottleMs))

--- a/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractCreateTopicsRequestTest.scala
@@ -100,7 +100,7 @@ abstract class AbstractCreateTopicsRequestTest extends BaseRequestTest {
     request.data.topics.forEach { topic =>
       def verifyMetadata(socketServer: SocketServer) = {
         val metadata = sendMetadataRequest(
-          new MetadataRequest.Builder(List(topic.name()).asJava, true).build()).topicMetadata.asScala
+          new MetadataRequest.Builder(List(topic.name()).asJava, false).build()).topicMetadata.asScala
         val metadataForTopic = metadata.filter(_.topic == topic.name()).head
 
         val partitions = if (!topic.assignments().isEmpty)

--- a/core/src/test/scala/unit/kafka/server/AbstractMetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractMetadataRequestTest.scala
@@ -53,7 +53,7 @@ abstract class AbstractMetadataRequestTest extends BaseRequestTest {
   }
 
   protected def checkAutoCreatedTopic(autoCreatedTopic: String, response: MetadataResponse): Unit = {
-    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, response.errors.get(autoCreatedTopic))
+    assertEquals(Errors.LEADER_NOT_AVAILABLE, response.errors.get(autoCreatedTopic))
     assertEquals(Some(servers.head.config.numPartitions), zkClient.getTopicPartitionCount(autoCreatedTopic))
     for (i <- 0 until servers.head.config.numPartitions)
       TestUtils.waitForPartitionMetadata(servers, autoCreatedTopic, i)

--- a/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AutoTopicCreationManagerTest.scala
@@ -92,7 +92,7 @@ class AutoTopicCreationManagerTest {
                               isInternal: Boolean,
                               numPartitions: Int = 1,
                               replicationFactor: Short = 1): Unit = {
-    autoTopicCreationManager = new AutoTopicCreationManagerImpl(
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       metadataCache,
       Some(brokerToController),
@@ -121,7 +121,7 @@ class AutoTopicCreationManagerTest {
 
   @Test
   def testCreateTopicsWithForwardingDisabled(): Unit = {
-    autoTopicCreationManager = new AutoTopicCreationManagerImpl(
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       metadataCache,
       None,
@@ -137,7 +137,7 @@ class AutoTopicCreationManagerTest {
     createTopicAndVerifyResult(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicName, false)
 
     Mockito.verify(adminManager).createTopics(
-      ArgumentMatchers.eq(requestTimeout),
+      ArgumentMatchers.eq(0),
       ArgumentMatchers.eq(false),
       ArgumentMatchers.eq(Map(topicName -> getNewTopic(topicName))),
       ArgumentMatchers.eq(Map.empty),
@@ -151,7 +151,7 @@ class AutoTopicCreationManagerTest {
     props.setProperty(KafkaConfig.DefaultReplicationFactorProp, 3.toString)
     config = KafkaConfig.fromProps(props)
 
-    autoTopicCreationManager = new AutoTopicCreationManagerImpl(
+    autoTopicCreationManager = new DefaultAutoTopicCreationManager(
       config,
       metadataCache,
       Some(brokerToController),

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -169,10 +169,10 @@ class MetadataRequestTest extends AbstractMetadataRequestTest {
     assertEquals(2, response1.topicMetadata.size)
     var topicMetadata1 = response1.topicMetadata.asScala.head
     val topicMetadata2 = response1.topicMetadata.asScala.toSeq(1)
-    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicMetadata1.error)
+    assertEquals(Errors.LEADER_NOT_AVAILABLE, topicMetadata1.error)
     assertEquals(topic1, topicMetadata1.topic)
     // The topic creation will be delayed, and the name collision error will be swallowed.
-    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicMetadata2.error)
+    assertEquals(Errors.INVALID_TOPIC_EXCEPTION, topicMetadata2.error)
     assertEquals(topic2, topicMetadata2.topic)
 
     TestUtils.waitUntilLeaderIsElectedOrChanged(zkClient, topic1, 0)

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestTest.scala
@@ -163,8 +163,8 @@ class MetadataRequestTest extends AbstractMetadataRequestTest {
 
   @Test
   def testAutoCreateOfCollidingTopics(): Unit = {
-    val topic1 = "testAutoCreate_Topic"
-    val topic2 = "testAutoCreate.Topic"
+    val topic1 = "testAutoCreate.Topic"
+    val topic2 = "testAutoCreate_Topic"
     val response1 = sendMetadataRequest(new MetadataRequest.Builder(Seq(topic1, topic2).asJava, true).build)
     assertEquals(2, response1.topicMetadata.size)
     var topicMetadata1 = response1.topicMetadata.asScala.head

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
@@ -81,8 +81,8 @@ class MetadataRequestWithForwardingTest extends AbstractMetadataRequestTest {
 
   @Test
   def testAutoCreateOfCollidingTopics(): Unit = {
-    val topic1 = "testAutoCreate_Topic"
-    val topic2 = "testAutoCreate.Topic"
+    val topic1 = "testAutoCreate.Topic"
+    val topic2 = "testAutoCreate_Topic"
     val response1 = sendMetadataRequest(new MetadataRequest.Builder(Seq(topic1, topic2).asJava, true).build)
     assertEquals(2, response1.topicMetadata.size)
     var topicMetadata1 = response1.topicMetadata.asScala.head

--- a/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataRequestWithForwardingTest.scala
@@ -87,10 +87,10 @@ class MetadataRequestWithForwardingTest extends AbstractMetadataRequestTest {
     assertEquals(2, response1.topicMetadata.size)
     var topicMetadata1 = response1.topicMetadata.asScala.head
     val topicMetadata2 = response1.topicMetadata.asScala.toSeq(1)
-    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicMetadata1.error)
+    assertEquals(Errors.LEADER_NOT_AVAILABLE, topicMetadata1.error)
     assertEquals(topic1, topicMetadata1.topic)
     // The topic creation will be delayed, and the name collision error will be swallowed.
-    assertEquals(Errors.UNKNOWN_TOPIC_OR_PARTITION, topicMetadata2.error)
+    assertEquals(Errors.INVALID_TOPIC_EXCEPTION, topicMetadata2.error)
     assertEquals(topic2, topicMetadata2.topic)
 
     TestUtils.waitUntilLeaderIsElectedOrChanged(zkClient, topic1, 0)


### PR DESCRIPTION
- Non-existing partitions missing from response when auto creation not enabled in the request
- Check and act is not safe when inserting into inflight map
- Change value type of inflight map to Boolean since we don't need the value
- Set timeout of 0 in the call to `ZkAdminManager.createTopics` since we don't need to wait for full creation
- Fix log message which suggests that creation through `ZkAdminManager` is asynchronous
- Clean up error message when the number of live brokers is insufficient for the replication factor
- Reuse value of `MetadataCache.aliveBrokers` rather than recomputing for every partition
- Controller mutation quota was not setting version correctly. Fixed to use permissive quota which is consistent with current behavior

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
